### PR TITLE
fixing the building and linking issues

### DIFF
--- a/build_extopus_deps.sh
+++ b/build_extopus_deps.sh
@@ -2,11 +2,9 @@
 
 . `dirname $0`/sdbs.inc
 
-if python -V 2>&1 | egrep -q '2.[5-9]'; then
-:
-else
-   simplebuild http://www.python.org/ftp/python/2.7.1 Python-2.7.1.tgz
-fi
+# qooxdoo needs python 2.5 or newer
+${SDBS_SCRIPTS_DIR}/check_or_build_python2_5.sh
+
 
 for module in \
     Mojolicious \

--- a/check_or_build_python2_5.sh
+++ b/check_or_build_python2_5.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+. `dirname $0`/sdbs.inc
+
+if python -V 2>&1 | egrep -q '2.[5-9]'; then
+:
+else
+   simplebuild https://www.python.org/ftp/python/2.7.9/ \
+    Python-2.7.9.tgz
+fi
+

--- a/rrdtool.inc
+++ b/rrdtool.inc
@@ -54,11 +54,14 @@ function build_rrdtool_1_4 (){
         LDFLAGS="${R}${PREFIX}/lib -L${PREFIX}/lib"
 
     # http://sourceware.org/libffi/
-    simplebuild ${DEPS_ARCHIVE} libffi-3.0.13.tar.gz \
+    simplebuild ${DEPS_ARCHIVE} libffi-3.2.1.tar.gz \
         CFLAGS="-O3 -fPIC" \
         CPPFLAGS="-I${PREFIX}/include" \
         LDFLAGS="${R}${PREFIX}/lib -L${PREFIX}/lib"
 
+    # glib needs python 2.5 or newer
+    ${SDBS_SCRIPTS_DIR}/check_or_build_python2_5.sh
+    
     # http://ftp.gnome.org/pub/gnome/sources/glib/
     simplebuild ${DEPS_ARCHIVE} glib-2.42.0.tar.xz \
         CFLAGS="-O3 -fPIC" \

--- a/sdbs.inc
+++ b/sdbs.inc
@@ -11,11 +11,13 @@ if [ x`which wget` = x ]; then
  exit 1
 fi 
 
+bindir=`dirname "$0"`
+SDBS_SCRIPTS_DIR=`cd $bindir;pwd`
+
 PREFIX=${1:-${PREFIX:-""}}
 
 if [ ${PREFIX:-""} = "" ]; then
-     bindir=`dirname "$0"`
-     PREFIX=`cd $bindir/..;pwd`/thirdparty
+     PREFIX=`cd ${SDBS_SCRIPTS_DIR}/..;pwd`/thirdparty
 fi
 export PREFIX
 echo "Building in $PREFIX"
@@ -58,7 +60,7 @@ function prepare () {
  if [ ! -f $2.ok ]
  then 
    echo "**** doing $2 ****"
-   [ -f $2 ] || wget   --tries=0 --random-wait --passive-ftp $1/$2
+   [ -f $2 ] || wget --no-check-certificate --tries=0 --random-wait --passive-ftp $1/$2
    unset SRCDIR
    [ -f $2.srcdir ] && SRCDIR=`cat $2.srcdir`
    case $2 in


### PR DESCRIPTION
especially for CentOS5:
python moved to HTTPS repository, but SSL certificate validation fails

newer libffi has a proper pkgconfig file, so linking does not fail
